### PR TITLE
fix: upgrade to flow-bin ^0.112.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "eslint-plugin-jest": "^21.15.0",
     "eslint-plugin-promise": "^3.7.0",
     "eslint-plugin-react": "^7.7.0",
-    "flow-bin": "^0.69.0",
+    "flow-bin": "^0.112.0",
     "flow-copy-source": "^1.3.0",
     "gh-pages": "^1.1.0",
     "git-branch-is": "^0.1.0",

--- a/src/Popper.js
+++ b/src/Popper.js
@@ -30,7 +30,7 @@ export type PopperChildrenProps = {|
 |};
 export type PopperChildren = PopperChildrenProps => React.Node;
 
-export type PopperProps = {
+export type PopperProps = {|
   children: PopperChildren,
   eventsEnabled?: boolean,
   innerRef?: Ref,
@@ -38,12 +38,12 @@ export type PopperProps = {
   placement?: Placement,
   positionFixed?: boolean,
   referenceElement?: ReferenceElement,
-};
+|};
 
-type PopperState = {
+type PopperState = {|
   data: ?Data,
   placement: ?Placement,
-};
+|};
 
 const initialStyle = {
   position: 'absolute',
@@ -116,8 +116,8 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
     !this.popperNode || !this.state.data
       ? initialStyle
       : {
-          position: this.state.data.offsets.popper.position,
           ...this.state.data.styles,
+          position: this.state.data.offsets.popper.position,
         };
 
   getPopperPlacement = () =>

--- a/src/Reference.js
+++ b/src/Reference.js
@@ -5,18 +5,18 @@ import { ManagerReferenceNodeSetterContext } from './Manager';
 import { safeInvoke, unwrapArray, setRef } from './utils';
 import { type Ref } from "./RefTypes";
 
-export type ReferenceChildrenProps = { ref: Ref };
-export type ReferenceProps = {
+export type ReferenceChildrenProps = {| ref: Ref |};
+export type ReferenceProps = {|
   children: ReferenceChildrenProps => React.Node,
   innerRef?: Ref,
-};
+|};
 
-type InnerReferenceProps = {
+type InnerReferenceProps = {|
   setReferenceNode?: (?HTMLElement) => void,
-};
+|};
 
 class InnerReference extends React.Component<
-  ReferenceProps & InnerReferenceProps
+  {| ...ReferenceProps, ...InnerReferenceProps |}
 > {
   refHandler = (node: ?HTMLElement) => {
     setRef(this.props.innerRef, node)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3638,10 +3638,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
 
-flow-bin@^0.69.0:
-  version "0.69.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.69.0.tgz#053159a684a6051fcbf0b71a2eb19a9679082da6"
-  integrity sha512-SC5kiOiMk+8o1N2ZQ1mBfi0qBDYM+r6ZFQS7s+zXtyKrkbtCP+6JRTVvO3KXOnv568SK1G+Kg8/LlJwgyR+8Ug==
+flow-bin@^0.112.0:
+  version "0.112.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.112.0.tgz#6a21c31937c4a2f23a750056a364c598a95ea216"
+  integrity sha512-vdcuKv0UU55vjv0e2EVh1ZxlU+TSNT19SkE+6gT1vYzTKtzYE6dLuAmBIiS3Rg2N9D9HOI6TKSyl53zPtqZLrA==
 
 flow-copy-source@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
This is my first attempt at fixing #318 

Currently, I only fixed what broke after the upgrade flow-bin. But I have some comments :

- I've used exact types for the props of Popper and Reference. I think it's not a problem, because there doesn't appear to be any spreading whatsoever. Is it acceptable that I migrate the props types of other components, so they are exact as well ? For the sake of API consistency
- In `Popper.js`, the `position` style cannot be overwritten anymore by what's in `state.data.styles`. Is that OK ?