### PR TITLE
Fix infinite loop

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/index.umd.js": {
-    "bundled": 67296,
-    "minified": 23836,
-    "gzipped": 7176
+    "bundled": 88323,
+    "minified": 32847,
+    "gzipped": 9575
   },
   "dist/index.umd.min.js": {
-    "bundled": 31932,
-    "minified": 12958,
-    "gzipped": 4186
+    "bundled": 52955,
+    "minified": 21926,
+    "gzipped": 6619
   },
   "dist/index.esm.js": {
-    "bundled": 12751,
-    "minified": 7575,
-    "gzipped": 2077,
+    "bundled": 12824,
+    "minified": 7630,
+    "gzipped": 2103,
     "treeshaked": {
       "rollup": {
-        "code": 3790,
-        "import_statements": 137
+        "code": 3829,
+        "import_statements": 163
       },
       "webpack": {
-        "code": 4900
+        "code": 4978
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "create-react-context": "^0.3.0",
+    "deep-equal": "^1.1.1",
     "popper.js": "^1.14.4",
     "prop-types": "^15.6.1",
     "typed-styles": "^0.0.7",

--- a/src/Popper.js
+++ b/src/Popper.js
@@ -1,4 +1,5 @@
 // @flow
+import deepEqual from "deep-equal";
 import * as React from 'react';
 import PopperJS, {
   type Placement,
@@ -165,7 +166,7 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
       this.props.placement !== prevProps.placement ||
       this.props.referenceElement !== prevProps.referenceElement ||
       this.props.positionFixed !== prevProps.positionFixed ||
-      this.props.modifiers !== prevProps.modifiers
+      !deepEqual(this.props.modifiers, prevProps.modifiers, {strict: true})
     ) {
 
       // develop only check that modifiers isn't being updated needlessly

--- a/yarn.lock
+++ b/yarn.lock
@@ -2661,6 +2661,18 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+deep-equal@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
+  integrity sha1-tcmMlCzv+vfLBR4k4UNKJaLmB2o=
+  dependencies:
+    is-arguments "^1.0.4"
+    is-date-object "^1.0.1"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object-keys "^1.1.1"
+    regexp.prototype.flags "^1.2.0"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -4313,6 +4325,11 @@ is-accessor-descriptor@^1.0.0:
   integrity sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
   dependencies:
     kind-of "^6.0.0"
+
+is-arguments@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
+  integrity sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM=
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -7544,6 +7561,13 @@ regexp-tree@^0.1.0:
     cli-table3 "^0.5.0"
     colors "^1.1.2"
     yargs "^10.0.3"
+
+regexp.prototype.flags@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz#6b30724e306a27833eeb171b66ac8890ba37e41c"
+  integrity sha1-azByTjBqJ4M+6xcbZqyIkLo35Bw=
+  dependencies:
+    define-properties "^1.1.2"
 
 regexpp@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
Popper.js' componentDidUpdate fails the props change test, which calls updatePopperInstance, which eventually causes componentDidUpdate to get called again. By using a deepEquals comparison on props.modifiers we correctly determine that the props did not update, and break the loop.

I don't have a nice simple repro for this issue, but it seems to only trigger in a complicated app on Chrome (at least 70.x->78.x) on Windows when the page's zoom level is less than 100%.