### PR TITLE
Export popper.js typings

### DIFF
--- a/typings/react-popper.d.ts
+++ b/typings/react-popper.d.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as PopperJS from "popper.js";
+export * from "popper.js";
 
 interface ManagerProps {
   children: React.ReactNode;


### PR DESCRIPTION
Export `popper.js` types from `react-popper` to avoid the `import/no-extraneous-dependencies` error from ESLINT when we need `popper.js` typings.