### PR TITLE
docs: add missing header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ One of the accepted placement values listed in the [Popper.js documentation](htt
 Your popper is going to be placed according to the value of this property.  
 Defaults to `bottom`.
 
+##### `outOfBoundaries`
+
 ```js
 outOfBoundaries: ?boolean;
 ```


### PR DESCRIPTION
When going through the `README.md` I noticed there was a missing header for the `outOfBoundaries` documentation, which made it look as it was part of `placement` documentation 🧐 💅🏻