### PR TITLE
fix: change initial position style based on positionFixed prop

### DIFF
--- a/src/Popper.js
+++ b/src/Popper.js
@@ -47,7 +47,6 @@ type PopperState = {
 };
 
 const initialStyle = {
-  position: 'absolute',
   top: 0,
   left: 0,
   opacity: 0,
@@ -113,14 +112,19 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
     },
   });
 
-  getPopperStyle = () =>
-    !this.popperNode || !this.state.data
-      ? initialStyle
+  getPopperStyle = () => {
+    const computedInitialStyle = {
+      ...initialStyle,
+      position: this.props.positionFixed ? 'fixed' : 'absolute',
+    }
+    return !this.popperNode || !this.state.data
+      ? computedInitialStyle
       : {
           position: this.state.data.offsets.popper.position,
           ...this.state.data.styles,
         };
-
+      
+      }
   getPopperPlacement = () =>
     !this.state.data ? undefined : this.state.placement;
 

--- a/src/Popper.js
+++ b/src/Popper.js
@@ -123,7 +123,6 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
           position: this.state.data.offsets.popper.position,
           ...this.state.data.styles,
         };
-      
       }
   getPopperPlacement = () =>
     !this.state.data ? undefined : this.state.placement;


### PR DESCRIPTION
I have a scenario where I am autofocusing an element appearing inside of a popper, and that is causing the page to scroll to the top when initially opened. A similar issue can be found here:

https://github.com/mui-org/material-ui/issues/16740

Their solution was to add `position: fixed` to the initial styles on the popper, but this library doesn't offer a way to do that. This PR makes it so that initial position style will either be `absolute` or `fixed` based on the `positionFixed` prop provided to the Popper component.