### PR TITLE
fix: update react-popper.d.ts

### DIFF
--- a/typings/react-popper.d.ts
+++ b/typings/react-popper.d.ts
@@ -77,7 +77,7 @@ export function usePopper<Modifiers>(
 ): {
   styles: { [key: string]: React.CSSProperties };
   attributes: { [key: string]: { [key: string]: string } };
-  state: PopperJS.State;
+  state: PopperJS.State | null;
   update: PopperJS.Instance['update'] | null;
   forceUpdate: PopperJS.Instance['forceUpdate'] | null;
 };


### PR DESCRIPTION
`state` property is null for the first time