### PR TITLE
Don't return a value in useEffect callback

### DIFF
--- a/src/Popper.js
+++ b/src/Popper.js
@@ -62,10 +62,9 @@ export function Popper({
   const [popperElement, setPopperElement] = React.useState(null);
   const [arrowElement, setArrowElement] = React.useState(null);
 
-  React.useEffect(() => setRef(innerRef, popperElement), [
-    innerRef,
-    popperElement,
-  ]);
+  React.useEffect(() => {
+    setRef(innerRef, popperElement)
+  }, [innerRef, popperElement]);
 
   const options = React.useMemo(
     () => ({


### PR DESCRIPTION
Not sure how no one has had this issue yet, but it made my code fail all over the place when upgrading from v1 to v2. The console was filled with these:

> Warning: An effect function must not return anything besides a function, which is used for clean-up. You returned null. If your effect does not require clean up, return undefined (or nothing).

I tracked it down to this effect using an implicit-return arrow function for a callback.