### PR TITLE
Make Popper innerRef available in componentDidMount and componentDidUpdate phase

### DIFF
--- a/src/Popper.js
+++ b/src/Popper.js
@@ -61,10 +61,13 @@ export function Popper({
 
   const [popperElement, setPopperElement] = React.useState(null);
   const [arrowElement, setArrowElement] = React.useState(null);
-
-  React.useEffect(() => {
-    setRef(innerRef, popperElement)
-  }, [innerRef, popperElement]);
+  const popperElementRefHandler = React.useCallback(
+    (element: HTMLElement | null) => {
+      setRef(innerRef, element);
+      setPopperElement(element);
+    },
+    [innerRef, setPopperElement]
+  );
 
   const options = React.useMemo(
     () => ({
@@ -91,7 +94,7 @@ export function Popper({
 
   const childrenProps = React.useMemo(
     () => ({
-      ref: setPopperElement,
+      ref: popperElementRefHandler,
       style: styles.popper,
       placement: state ? state.placement : placement,
       hasPopperEscaped:
@@ -110,7 +113,7 @@ export function Popper({
       update: update || NOOP_PROMISE,
     }),
     [
-      setPopperElement,
+      popperElementRefHandler,
       setArrowElement,
       placement,
       state,


### PR DESCRIPTION
During migration to `2.x` version of `popperjs` I got an unexpected error in one of my components that using legacy `react-popper` API. The component uses a value of `innerRef` in `componentDidMount` phase, but the `Popper` component calls `setRef` in `useEffect` which fires after `componentDidMount`.

I think that legacy `react-popper` API should be compatible with `react` class components.
For example, in `1.x` version of `react-popper`, the `Popper` component behaves the same.
https://github.com/popperjs/react-popper/blob/b451e968fc28b9ab59775742d82c219e92d11f20/src/Popper.js#L76-L83

## What I did

I did a popper element ref handler with `setRef(innerRef, element)` and `setPopperElement(element)`.

## How to test

This component should render correctly:

```js
const referenceElement = document.createElement('div');

class MyComponent extends React.Component {
  popperElementRef = React.createRef();

  componentDidMount() {
    assert(this.popperElementRef.current !== null);
  }

  render() {
    return (
      <Popper
        referenceElement={referenceElement}
        innerRef={this.popperElementRef}
      >
        {({ ref, style, placement }) => (
          <div ref={ref} style={style} data-placement={placement} />
        )}
      </Popper>
    );
  }
}
```
