### PR TITLE
fix: Returns correct state when referenceElement becomes null

### DIFF
--- a/src/usePopper.js
+++ b/src/usePopper.js
@@ -107,6 +107,10 @@ export const usePopper = (
 
   useIsomorphicLayoutEffect(() => {
     if (referenceElement == null || popperElement == null) {
+      if (popperInstanceRef.current) {
+        popperInstanceRef.current.destroy();
+        popperInstanceRef.current = null;
+      }
       return;
     }
 


### PR DESCRIPTION
When I change `referenceElement` or `popperElement` to `null`, `usePopper` returns old state to me.

## Steps To Reproduce

1. open the reproduce link: https://codepen.io/lmk123/pen/zYrRzMM
2. click the 'Set referenceElement to null' button

Expected behavior: `state.placement` becomes `null`
Current behavior: `state.placement` is still `bottom`

