### PR TITLE
fix(hooks): Avoid setState in unmounted components.

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -13,16 +13,24 @@ export type ManagerProps = {
 export function Manager({ children }: ManagerProps) {
   const [referenceNode, setReferenceNode] = React.useState<?Element>(null);
 
-  React.useEffect(
-    () => () => {
-      setReferenceNode(null);
-    },
-    [setReferenceNode]
-  );
+  const hasUnmounted = React.useRef(false);
+  React.useEffect(() => {
+    return () => {
+      hasUnmounted.current = true;
+    };
+  }, []);
+
+  const handleSetReferenceNode = React.useCallback((node) => {
+    if (!hasUnmounted.current) {
+      setReferenceNode(node);
+    }
+  }, []);
 
   return (
     <ManagerReferenceNodeContext.Provider value={referenceNode}>
-      <ManagerReferenceNodeSetterContext.Provider value={setReferenceNode}>
+      <ManagerReferenceNodeSetterContext.Provider
+        value={handleSetReferenceNode}
+      >
         {children}
       </ManagerReferenceNodeSetterContext.Provider>
     </ManagerReferenceNodeContext.Provider>


### PR DESCRIPTION
I ran into an issue with react-popper v2.2.3, and I believe this is the right way to fix it. These changes have worked for me locally in my app that had previously been crashing.

The error message that React has been giving me is "Invalid hook call", although I know from previous experience that the error message is incredibly misleading and can be caused by many different issues.
https://reactjs.org/docs/error-decoder.html/?invariant=321

I believe the underlying issue is with calling `setState` (or here, `setReferenceNode`) after the component has unmounted. `setState` happens asynchronously and is therefore inappropriate inside the cleanup function for a `useEffect` hook.

I removed the other cleanup function in this PR because I believe it to no longer be necessary. It was added to prevent a memory leak back when this component was a class component, but it should not be necessary anymore in this function component.