### PR TITLE
Update react-popper.d.ts

### DIFF
--- a/typings/react-popper.d.ts
+++ b/typings/react-popper.d.ts
@@ -76,7 +76,7 @@ export function usePopper<Modifiers>(
   }
 ): {
   styles: { [key: string]: React.CSSProperties };
-  attributes: { [key: string]: { [key: string]: string } };
+  attributes: { [key: string]: { [key: string]: string } | undefined };
   state: PopperJS.State | null;
   update: PopperJS.Instance['update'] | null;
   forceUpdate: PopperJS.Instance['forceUpdate'] | null;


### PR DESCRIPTION
The current type doesn't show that the popper object may be undefined during the first render.

```ts
const { styles, attributes } = usePopper(...

console.log(attributes.popper);
```

when rendering the object is first undefined then during a second render it's populated:

![image](https://user-images.githubusercontent.com/1706321/95222733-cf6edb80-07c6-11eb-9249-5f9438de8bd0.png)

This type update would reflect that fact in TS

![image](https://user-images.githubusercontent.com/1706321/95222909-0218d400-07c7-11eb-9e0e-62ecc6d2f54a.png)



 