### PR TITLE
Upgrade flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -9,7 +9,6 @@
 [lints]
 
 [options]
-suppress_comment=\\(.\\|\n\\)*\\$FlowExpectError
 
 [strict]
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -9,6 +9,7 @@
 [lints]
 
 [options]
+types_first=false
 
 [strict]
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^3.0.0",
-    "flow-bin": "^0.127.0",
+    "flow-bin": "^0.132.0",
     "flow-copy-source": "^2.0.9",
     "gh-pages": "^2.2.0",
     "git-branch-is": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^3.0.0",
-    "flow-bin": "^0.132.0",
+    "flow-bin": "^0.139.0",
     "flow-copy-source": "^2.0.9",
     "gh-pages": "^2.2.0",
     "git-branch-is": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^3.0.0",
-    "flow-bin": "^0.122.0",
+    "flow-bin": "^0.127.0",
     "flow-copy-source": "^2.0.9",
     "gh-pages": "^2.2.0",
     "git-branch-is": "^3.1.0",

--- a/src/Popper.test.js
+++ b/src/Popper.test.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { render, waitFor, act } from '@testing-library/react';
 import * as PopperJs from '@popperjs/core';
+import type { Ref } from './RefTypes';
 
 // Public API
 import { Popper } from '.';
@@ -20,6 +21,14 @@ const renderPopper = async (props): any => {
     );
   });
   return result;
+};
+
+const handleRef = (ref: Ref) => (node: ?HTMLElement) => {
+  if (typeof ref === 'function') {
+    ref(node);
+  } else if (typeof ref === 'function') {
+    ref.current = node;
+  }
 };
 
 describe('Popper component', () => {
@@ -41,11 +50,11 @@ describe('Popper component', () => {
         <Popper referenceElement={referenceElement}>
           {({ ref, style, placement, arrowProps }) => (
             <div
-              ref={(current) => ref(current)}
+              ref={handleRef(ref)}
               style={style}
               data-placement={placement}
             >
-              <div {...arrowProps} ref={(current) => arrowProps.ref(current)} />
+              <div {...arrowProps} ref={handleRef(arrowProps.ref)} />
             </div>
           )}
         </Popper>

--- a/src/RefTypes.js
+++ b/src/RefTypes.js
@@ -1,4 +1,5 @@
+// @flow
 type RefHandler = (?HTMLElement) => void;
-type RefObject = { current?: HTMLElement};
+type RefObject = { current?: ?HTMLElement};
 
 export type Ref = RefHandler | RefObject;

--- a/src/__typings__/main-test.js
+++ b/src/__typings__/main-test.js
@@ -8,7 +8,7 @@ import { Manager, Reference, Popper } from '..';
 
 export const Test = () => (
   <Manager>
-    {/* $FlowExpectError: empty children */}
+    {/* $FlowExpectedError: empty children */}
     <Reference />
     <Reference>{({ ref }) => <div ref={ref} />}</Reference>
     <Popper

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,10 +3648,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.122.0:
-  version "0.122.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.122.0.tgz#c723a2b33b1a70bd10204704ae1dc776d5d89d79"
-  integrity sha512-my8N5jgl/A+UVby9E7NDppHdhLgRbWgKbmFZSx2MSYMRh3d9YGnM2MM+wexpUpl0ftY1IM6ZcUwaAhrypLyvlA==
+flow-bin@^0.127.0:
+  version "0.127.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.127.0.tgz#0614cff4c1b783beef1feeb7108d536e09d77632"
+  integrity sha512-ywvCCdV4NJWzrqjFrMU5tAiVGyBiXjsJQ1+/kj8thXyX15V17x8BFvNwoAH97NrUU8T1HzmFBjLzWc0l2319qg==
 
 flow-copy-source@^2.0.9:
   version "2.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,10 +3648,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.127.0:
-  version "0.127.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.127.0.tgz#0614cff4c1b783beef1feeb7108d536e09d77632"
-  integrity sha512-ywvCCdV4NJWzrqjFrMU5tAiVGyBiXjsJQ1+/kj8thXyX15V17x8BFvNwoAH97NrUU8T1HzmFBjLzWc0l2319qg==
+flow-bin@^0.132.0:
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.132.0.tgz#8bf80a79630db24bd1422dc2cc4b5e97f97ccb98"
+  integrity sha512-S1g/vnAyNaLUdajmuUHCMl30qqye12gS6mr4LVyswf1k+JDF4efs6SfKmptuvnpitF3LGCVf0TIffChP8ljwnw==
 
 flow-copy-source@^2.0.9:
   version "2.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,10 +3648,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.132.0:
-  version "0.132.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.132.0.tgz#8bf80a79630db24bd1422dc2cc4b5e97f97ccb98"
-  integrity sha512-S1g/vnAyNaLUdajmuUHCMl30qqye12gS6mr4LVyswf1k+JDF4efs6SfKmptuvnpitF3LGCVf0TIffChP8ljwnw==
+flow-bin@^0.139.0:
+  version "0.139.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.139.0.tgz#3ad6c75460be45b64f00521035c5affb3c440df5"
+  integrity sha512-eilVetLwztYtKjRj//4OsJ7aw47hsUZ8GTINxaZHWhpqiFikErQL0sV/3hQtpm54w9FuS2PO4yvbU0pWrtckqg==
 
 flow-copy-source@^2.0.9:
   version "2.0.9"


### PR DESCRIPTION
I'm getting flow errors from `react-propper` in my `node_modules`, so I figured I'd upgrade it.

One notable thing I found is that [this file](https://github.com/popperjs/react-popper/blob/master/src/RefTypes.js#L1) doesn't actually have a flow directive so it's not being parsed by flow, and therefore everything being imported from it is `any`.