### PR TITLE
use @hypnosphi/create-react-context to support react 17 in v1

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -10,16 +10,16 @@
     "gzipped": 4186
   },
   "dist/index.esm.js": {
-    "bundled": 12751,
-    "minified": 7575,
-    "gzipped": 2077,
+    "bundled": 12762,
+    "minified": 7586,
+    "gzipped": 2087,
     "treeshaked": {
       "rollup": {
-        "code": 3790,
-        "import_statements": 137
+        "code": 3801,
+        "import_statements": 148
       },
       "webpack": {
-        "code": 4900
+        "code": 4911
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "create-react-context": "^0.3.0",
+    "@hypnosphi/create-react-context": "^0.3.1",
     "popper.js": "^1.14.4",
     "prop-types": "^15.6.1",
     "typed-styles": "^0.0.7",

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import createContext, { type Context } from 'create-react-context';
+import createContext, { type Context } from '@hypnosphi/create-react-context';
 
 export const ManagerReferenceNodeContext: Context<?HTMLElement> = createContext();
 export const ManagerReferenceNodeSetterContext: Context<

--- a/yarn.lock
+++ b/yarn.lock
@@ -792,6 +792,14 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
   integrity sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==
 
+"@hypnosphi/create-react-context@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz#f8bfebdc7665f5d426cba3753e0e9c7d3154d7c6"
+  integrity sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==
+  dependencies:
+    gud "^1.0.0"
+    warning "^4.0.3"
+
 "@iarna/toml@^2.2.0":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.1.tgz#82d0993d8882bb05e0645fbb4731d9e939e895b3"
@@ -2330,14 +2338,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-create-react-context@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
-  integrity sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
-  dependencies:
-    gud "^1.0.0"
-    warning "^4.0.3"
 
 cross-env@^5.1.4:
   version "5.2.0"


### PR DESCRIPTION
Addresses #405 

In short: `create-react-context` doesn't support react v17, and since it looks to be abandoned, use `@hypnosphi/create-react-context` instead.