### PR TITLE
Only set Reference's innerRef to null when unmounting

### DIFF
--- a/src/Reference.js
+++ b/src/Reference.js
@@ -23,7 +23,7 @@ export function Reference({ children, innerRef }: ReferenceProps): React.Node {
   );
 
   // ran on unmount
-  React.useEffect(() => () => setRef(innerRef, null));
+  React.useEffect(() => () => setRef(innerRef, null), []);
 
   React.useEffect(() => {
     warning(


### PR DESCRIPTION
Without this, the reference is set to null for _every render_, making
it mostly unusable.